### PR TITLE
Set namespace in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.amorenew.mobile_number'
     compileSdkVersion 33
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'com.amorenew.mobile_number'
+    namespace = 'com.amorenew.mobile_number'
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
This pull request addresses the issue of the build.gradle file lacking a defined namespace for the project, which is introduced after it is upgraded to v8 of the Android Gradle plugin. According to the Android [documentation](https://developer.android.com/build/configure-app-module#set-namespace), it is recommended to set the namespace explicitly and keep it the same as the application ID for a simpler workflow.

The changes in this PR add the following line to the build.gradle file:

```gradle
android {
    namespace = "com.amorenew.mobile_number"
    ...
}
```
The namespace is set to com.amorenew.mobile_number, which matches the project's application ID.
By setting the namespace, we ensure that the generated R and BuildConfig classes are created in the correct package, and that any resources or code that reference these classes can import them correctly.

Included below is a screenshot that shows the error message I encountered when trying to build the project without a defined namespace.
![Blurred Screenshot _mobile_number namespace error](https://github.com/amorenew/Flutter-Mobile-Number-Plugin/assets/45206423/de7367cb-5422-4976-b09f-fee1155588b8)

Furthermore, I've tested these changes locally, and the project builds successfully with the added namespace.

Please review the changes, and let me know if you have any concerns or suggestions for improvement.